### PR TITLE
Renaming "Open Named Sessions" to "Active Named Sessions" plus minor changes

### DIFF
--- a/DEVPLANS.md
+++ b/DEVPLANS.md
@@ -69,9 +69,10 @@
   - When the user restores a session, the saved tabs are reopened.
 
 - **Tab Synchronization**
+  (TODO: Improve this section)
   - The backend bookmark folder is updated by a timer of manual trigger.
   - Duration between the triggers can be configured in Settings UI
-  - When the trigger runs on the Extension with clientId "C", for the Open Named Sessions,
+  - When the trigger runs on the Extension with clientId "C", for the active named sessions,
     - If the last syncedAt metadata is
     - If the set of the current Open Tabs differs from the Open Tabs synced in the backend with the same ownerId "C", save back to the backend, creating, updating, and deleting them. This automatic sync only processes the owned (by "C").
   - The user can let the extension "take over" the synced Open Tabs using the UI in Tabs UI.

--- a/NEXT_TODO.md
+++ b/NEXT_TODO.md
@@ -1,7 +1,7 @@
 This is a work stack. Take the top one and process it.
 
 - Find a TODO which requires the smallest changes and work on the implementation.
-  - You may use `find *.html src/ *.md designdocs/ -type f | xargs grep TODO | head -n100`
+  - You may use `find *.html src/ *.md designdocs/ -type f | xargs grep TODO | shuf | head -n100`
 
 ---
 

--- a/designdocs/concepts.md
+++ b/designdocs/concepts.md
@@ -32,12 +32,9 @@
 
 - Consists of sessions stored in Chrome's Bookmarks. This backup enables session restoration even when the associated window is closed.
 
-### Open Named Sessions
+### Active Named Sessions
 
-- A session
-- Hence, associated with a window in the current browser.
-
-- Open Named Sessions are managed locally using Chrome's storage API under the key "hacky_helper_named_sessions". They represent active sessions associated with current browser windows and are updated in real-time.
+Active Named Sessions represent sessions that are currently active and bound to their respective browser windows. They are managed locally via Chrome's storage API using the key "hacky_helper_named_sessions" and are continuously updated in real-time to reflect the current state.
 
 ### Closed Named Sessions
 
@@ -67,7 +64,7 @@
   <tr>
     <td rowspan="3">Session</td>
     <td rowspan="2">Named</td>
-    <td>Open</td>
+    <td>Active</td>
     <td>✅</td>
     <td>✅</td>
     <td>✅</td>
@@ -91,8 +88,7 @@
     <td>-</td>
   </tr>
   <tr>
-    <td rowspan="2">Open Tabs</td>
-    <td rowspan="2"><i>n/a</i></td>
+    <td rowspan="2" colspan="2">Open Tabs</td>
     <td>Synced</td>
     <td>✅</td>
     <td></i>depends</i></td>

--- a/designdocs/tabs_ui.md
+++ b/designdocs/tabs_ui.md
@@ -39,7 +39,7 @@ Tabs UI is an extention component
 
 - Incremental search on user typing.
 - Search results shows results for categorized into these:
-  - Open Named Sessions
+  - Active Named Sessions
   - Closed Named Sessions
   - Open Tabs in any of the windows
 

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "storage",
     "unlimitedStorage",
     "tabs",
+    "notifications",
     "alarms",
     "bookmarks"
   ],

--- a/src/features/config-store.ts
+++ b/src/features/config-store.ts
@@ -244,6 +244,7 @@ interface ConfigRO {
 }
 /**
  * Retrieves all configuration settings.
+ * TODO: Replace the callers with ConfigStoreRO.
  * @returns An object containing all configuration settings.
  */
 export async function getConfig(): Promise<ConfigRO> {

--- a/src/features/search-functionality.ts
+++ b/src/features/search-functionality.ts
@@ -154,8 +154,9 @@ async function showSearchResults(query: string): Promise<void> {
       await serviceWorkerInterface.getNamedSessions();
     const closedSessions: ClosedNamedSession[] =
       await serviceWorkerInterface.getClosedNamedSessions();
-    // Calculate openNamedSessions by excluding closed sessions from named sessions
-    const openNamedSessions: NamedSession[] = namedSessions.filter(
+    // TODO: we can actually fetch active named sessions direclty.
+    // Calculate activeNamedSessions by excluding closed sessions from named sessions
+    const activeNamedSessions: NamedSession[] = namedSessions.filter(
       (session: NamedSession) =>
         !closedSessions.find(
           (closed: ClosedNamedSession) => closed.id === session.id,
@@ -163,7 +164,7 @@ async function showSearchResults(query: string): Promise<void> {
     );
 
     // Filter sessions based on query
-    const matchingNamedSessions = openNamedSessions
+    const matchingNamedSessions = activeNamedSessions
       .filter((session: NamedSession) =>
         session.name.toLowerCase().includes(normalizedQuery),
       )
@@ -337,7 +338,7 @@ function addResultsCategory(
       onClick: () => {
         hideSearchResults();
         // TODO: instead of passing a click event, we want to trigger desired actions per results.
-        //       - Activate the session for Open Named Sessions.
+        //       - Activate the window for Active Named Sessions.
         //       - Restore the session for Closed Named Sessions.
         //       - Activate the tab for a open tab in any of the windows.
         if (result.session) {

--- a/src/features/session-management.ts
+++ b/src/features/session-management.ts
@@ -1,10 +1,10 @@
 /**
  * @file session-management.ts
  *
- * This file manages open named sessions "in local" using Chrome extensions' local storage API
+ * This file manages active named sessions "in local" using Chrome extensions' local storage API
  * and syncs them with the backend when necessary.
  */
-// TODO: Document about the methods that session-management manages open named sessions "in local" using chrome extensions local strorage API, and sync that with the backedn when necessary.
+// TODO: Document about the methods that session-management manages active named sessions "in local" using chrome extensions local strorage API, and sync that with the backedn when necessary.
 
 import {
   ClosedNamedSession,
@@ -26,7 +26,7 @@ const NAMED_SESSIONS_STORAGE_KEY = "hacky_helper_named_sessions";
 /**
  * Gets all named sessions from storage and verifies window existence.
  */
-async function getOpenNamedSessionsInLocal(): Promise<
+async function getActiveNamedSessionsInLocal(): Promise<
   Record<string, NamedSession>
 > {
   try {
@@ -86,23 +86,22 @@ async function getOpenNamedSessionsInLocal(): Promise<
 
 /**
  * Gets a specific named session from storage by ID
- * TODO: Have a better naming. This only returns open sessions.
  */
-async function getOpenNamedSessionInLocal(
+async function getActiveNamedSession(
   sessionId: string,
 ): Promise<NamedSession | null> {
-  const sessions = await getOpenNamedSessionsInLocal();
+  const sessions = await getActiveNamedSessionsInLocal();
   return sessions[sessionId] || null;
 }
 
 /**
  * Saves a named session to storage
  */
-async function saveOpenNamedSessionInLocal(
+async function saveActiveNamedSessionInLocal(
   session: NamedSession,
 ): Promise<void> {
   try {
-    const sessions = await getOpenNamedSessionsInLocal();
+    const sessions = await getActiveNamedSessionsInLocal();
     sessions[session.id] = session;
     // TODO: Ideally we want to save data per session.
     await chrome.storage.local.set({
@@ -117,9 +116,11 @@ async function saveOpenNamedSessionInLocal(
 /**
  * Deletes a named session from storage
  */
-async function deleteOpenNamedSessionInLocal(sessionId: string): Promise<void> {
+async function deleteActiveNamedSessionInLocal(
+  sessionId: string,
+): Promise<void> {
   try {
-    const sessions = await getOpenNamedSessionsInLocal();
+    const sessions = await getActiveNamedSessionsInLocal();
     if (sessions[sessionId]) {
       delete sessions[sessionId];
       await chrome.storage.local.set({
@@ -139,7 +140,7 @@ export async function reassociateNamedSessionInLocal(
   // TODO: We would rather check if we have a closed named session with the given sessionId.
   //       and if found only update the session association in-local.
   // Check for closed session
-  const activeSessions = await getOpenNamedSessionsInLocal();
+  const activeSessions = await getActiveNamedSessionsInLocal();
   const activeSessionIds = Object.keys(activeSessions);
   const closedSessions =
     await BookmarkStorage.getInstance().getClosedNamedSessions(
@@ -156,7 +157,7 @@ export async function reassociateNamedSessionInLocal(
       updatedAt: Date.now(),
     };
     try {
-      await saveOpenNamedSessionInLocal(updatedSession);
+      await saveActiveNamedSessionInLocal(updatedSession);
       console.log(
         `Reassociated closed session ${sessionId} to window ${windowId}`,
       );
@@ -364,7 +365,7 @@ export async function createNamedSession(
   };
 
   // Save to persistent storage
-  await saveOpenNamedSessionInLocal(session);
+  await saveActiveNamedSessionInLocal(session);
 
   // Save session to Bookmark API for syncing if it has a name and is not being restored from bookmarks
   if (sessionName && !isRestoringFromBookmarks) {
@@ -394,7 +395,7 @@ export async function updateNamedSessionTabs(
   windowId?: number,
   isRestoringFromBookmarks: boolean = false,
 ) {
-  const session = await getOpenNamedSessionInLocal(sessionId);
+  const session = await getActiveNamedSession(sessionId);
   if (!session) {
     console.warn(
       `Cannot update Named Session tabs: Session not found for session ${sessionId}`,
@@ -438,7 +439,7 @@ export async function updateNamedSessionTabs(
     session.updatedAt = Date.now();
 
     // Save updated session to storage
-    await saveOpenNamedSessionInLocal(session);
+    await saveActiveNamedSessionInLocal(session);
 
     // Update Bookmark API to reflect new tabs if the session has a name and we're not restoring from bookmarks
     // TODO: if-structure can be simplified?
@@ -476,7 +477,7 @@ export async function renameNamedSession(
   }
 
   // Get the session from storage
-  const session = await getOpenNamedSessionInLocal(sessionId);
+  const session = await getActiveNamedSession(sessionId);
   if (!session) {
     console.warn(
       `Cannot rename session: Session not found for ID ${sessionId}`,
@@ -489,7 +490,7 @@ export async function renameNamedSession(
   session.updatedAt = Date.now();
 
   // Save to persistent storage
-  await saveOpenNamedSessionInLocal(session);
+  await saveActiveNamedSessionInLocal(session);
 
   // Update the session in bookmark storage
   await syncSessionToBackend(session);
@@ -500,11 +501,11 @@ export async function renameNamedSession(
 
 /**
  * Deletes a Named Session by its sessionId.
- * Checks both storage and bookmark storage for closed sessions.
+ * Checks both in-local for active and in-backendfor closed sessions.
  */
 export async function deleteNamedSession(sessionId: string) {
   // Check if the session exists in storage
-  const session = await getOpenNamedSessionInLocal(sessionId);
+  const session = await getActiveNamedSession(sessionId);
   if (session) {
     // Remove corresponding Bookmark folder if the session has a name
     if (session.name) {
@@ -512,13 +513,13 @@ export async function deleteNamedSession(sessionId: string) {
     }
 
     // Remove from storage
-    await deleteOpenNamedSessionInLocal(sessionId);
+    await deleteActiveNamedSessionInLocal(sessionId);
 
     console.log(`Deleted Named Session ${sessionId}`);
     return true;
   } else {
     // Check if this is a closed session in bookmark storage
-    const activeSessions = await getOpenNamedSessionsInLocal();
+    const activeSessions = await getActiveNamedSessionsInLocal();
     const activeSessionIds = Object.keys(activeSessions);
     const closedSessions =
       await BookmarkStorage.getInstance().getClosedNamedSessions(
@@ -560,7 +561,7 @@ export async function cloneNamedSession(
   originalSessionId: string,
 ): Promise<NamedSession | null> {
   // We assume the orignal session is open.
-  const originalSession = await getOpenNamedSessionInLocal(originalSessionId);
+  const originalSession = await getActiveNamedSession(originalSessionId);
   if (!originalSession || !originalSession.windowId) {
     console.error(
       `Cannot clone session: session ${originalSessionId} not found or invalid.`,
@@ -640,7 +641,7 @@ export async function cloneNamedSession(
  */
 export async function getNamedSessions(): Promise<NamedSession[]> {
   // Get active sessions from storage
-  const activeSessions = await getOpenNamedSessionsInLocal();
+  const activeSessions = await getActiveNamedSessionsInLocal();
   const activeSessionsArray = Object.values(activeSessions);
 
   // Get closed sessions from bookmarks
@@ -672,7 +673,7 @@ export async function getNamedSessions(): Promise<NamedSession[]> {
 export async function getClosedNamedSessions(): Promise<ClosedNamedSession[]> {
   try {
     // Get all active session IDs from storage
-    const sessions = await getOpenNamedSessionsInLocal();
+    const sessions = await getActiveNamedSessionsInLocal();
     const activeSessionIds = Object.keys(sessions);
 
     // Get closed sessions from bookmark storage
@@ -716,7 +717,7 @@ export async function restoreClosedSession(
 ): Promise<NamedSession | null> {
   try {
     // Get the closed session from bookmarks
-    const sessions = await getOpenNamedSessionsInLocal();
+    const sessions = await getActiveNamedSessionsInLocal();
     const activeSessionIds = Object.keys(sessions);
     const closedSessions =
       await BookmarkStorage.getInstance().getClosedNamedSessions(
@@ -877,7 +878,7 @@ async function autoSaveAllSessions() {
     console.log("Auto-saving all named sessions to bookmarks");
 
     // Get all named sessions from storage
-    const sessions = Object.values(await getOpenNamedSessionsInLocal());
+    const sessions = Object.values(await getActiveNamedSessionsInLocal());
 
     // Filter to only include sessions with names
     const namedSessionsOnly = sessions.filter((session) => session.name);

--- a/src/features/session-management.ts
+++ b/src/features/session-management.ts
@@ -410,7 +410,6 @@ export async function updateNamedSessionTabs(
         `Duplicate Tabs UI instance for session ${sessionId}: existing windowId ${session.windowId} vs new windowId ${windowId}. Skipping update.`,
       );
       if (chrome.notifications) {
-        // TODO: Add the permission in the manifest.
         chrome.notifications.create({
           type: "basic",
           iconUrl: chrome.runtime.getURL("icon.png"),


### PR DESCRIPTION
This pull request includes several changes to improve the terminology and functionality of session management, as well as some minor updates and additions. The most important changes involve renaming "Open Named Sessions" to "Active Named Sessions" across various files, updating session management functions, and adding new permissions to the manifest.

Terminology Update:
* [`designdocs/concepts.md`](diffhunk://#diff-78f594154204ac6be23b7f596d8f6931463a95bb747e3d7dfd2062526f4f897aL35-R37): Renamed "Open Named Sessions" to "Active Named Sessions" and updated descriptions to reflect the new terminology. [[1]](diffhunk://#diff-78f594154204ac6be23b7f596d8f6931463a95bb747e3d7dfd2062526f4f897aL35-R37) [[2]](diffhunk://#diff-78f594154204ac6be23b7f596d8f6931463a95bb747e3d7dfd2062526f4f897aL70-R67) [[3]](diffhunk://#diff-78f594154204ac6be23b7f596d8f6931463a95bb747e3d7dfd2062526f4f897aL94-R91)
* [`designdocs/tabs_ui.md`](diffhunk://#diff-4c77b8cbcb77700b606c85b040ad5e569be8291cb419a4490a66f66af14cb8e6L42-R42): Updated references to "Open Named Sessions" to "Active Named Sessions" in the search results section.
* [`src/features/session-management.ts`](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L29-R29): Renamed functions and variables from "Open Named Sessions" to "Active Named Sessions" to reflect the updated terminology. [[1]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L29-R29) [[2]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L89-R104) [[3]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L120-R123) [[4]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L142-R143) [[5]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L159-R160) [[6]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L367-R368) [[7]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L397-R398) [[8]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L413) [[9]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L442-R442) [[10]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L480-R480) [[11]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L493-R493) [[12]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L504-R522) [[13]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L564-R564) [[14]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L644-R644) [[15]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L676-R676) [[16]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L720-R720) [[17]](diffhunk://#diff-6e0dece36484bf590cc4469cab800aad651cb6d290d126a0e96217350f7b7899L881-R881)

Functionality Update:
* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R11): Added "notifications" permission to the manifest to support new notification features.

Minor Updates:
* [`DEVPLANS.md`](diffhunk://#diff-69951a3989cb179dbc8fa978561f8db277dcf02b2e36d88f75a8f41a5a508082R72-R75): Added a TODO note to improve the "Tab Synchronization" section.
* [`NEXT_TODO.md`](diffhunk://#diff-3b4c35f29943b9a1f66fd5dd4d135ecaa23776eced2d0ba2fd35bab0e0260ce8L4-R4): Updated the command to shuffle the TODO list before displaying the top 100 items.
* [`src/features/config-store.ts`](diffhunk://#diff-86ff93c24b8cfd5bc3d669332c0968cb2a3fe36ac93767168269005703840b41R247): Added a TODO note to replace callers with `ConfigStoreRO`.
* [`src/features/search-functionality.ts`](diffhunk://#diff-9a9588fd1ca51a5a4fda2dbedf0d56b1070127d699bbf5d56471e685bc13ae59L157-R167): Updated comments and variable names to reflect the new terminology of "Active Named Sessions". [[1]](diffhunk://#diff-9a9588fd1ca51a5a4fda2dbedf0d56b1070127d699bbf5d56471e685bc13ae59L157-R167) [[2]](diffhunk://#diff-9a9588fd1ca51a5a4fda2dbedf0d56b1070127d699bbf5d56471e685bc13ae59L340-R341)