### PR TITLE
feat: add copy-page-info command to copy current page title and URL

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,12 @@
         "default": "Alt+S"
       },
       "description": "Focus the search bar in Tabs UI of the current window."
+    },
+    "copy-page-info": {
+      "suggested_key": {
+        "default": "Alt+Shift+C"
+      },
+      "description": "Copy the current page title and URL for sharing."
     }
   }
 }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -3,6 +3,11 @@ import "./popup.css";
 import { CONFIG_STORE, CONFIG_RO } from "./features/config-store";
 import { MIGRATE_TAB } from "./lib/constants";
 import serviceWorkerInterface from "./features/service-worker-interface";
+import { handleMessages } from "./popup/popup-messages";
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  return handleMessages(message, sender, sendResponse);
+});
 
 // Function to initialize the toggle states from configuration
 async function initializeToggles() {

--- a/src/popup/popup-messages.ts
+++ b/src/popup/popup-messages.ts
@@ -1,0 +1,59 @@
+/**
+ * @file popup-messages.ts
+ *
+ * Provides functions to handle popup interactions for the Hacky Helper Chrome extension.
+ * Specifically, it handles messages such as copy-page-info.
+ *
+ * Captain Nova advises: "Don't Panic" and let the popup handle its own business.
+ */
+
+// Caller part.
+export function triggerCopyPageInfo() {
+  // Check if a popup view is already open.
+  // We assume this is called by service-worker, and need to openPopup() in any situation.
+  // TODO: Can it be rewritten to use promise+await?
+  chrome.action.openPopup(() => {
+    // After opening, send the message.
+    // TODO: Have a constant for `copyPageInfo` and rename it to something more consistent. e.g. POPUP_COPY_PAGE_INFO ?
+    chrome.runtime.sendMessage({ popup_action: "copyPageInfo", params: {} });
+  });
+}
+
+// Handler part
+export function handleMessages(
+  message: any,
+  _sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: any) => void,
+): boolean {
+  if (message.popup_action === "copyPageInfo") {
+    copyPageInfo(sendResponse);
+    return true;
+  }
+  return false;
+}
+
+// Function to copy page info by retrieving the active tab's title and URL
+// TODO: Use the shared definition of Success/Error Results.
+function copyPageInfo(sendResponse: (response?: any) => void) {
+  // TODO: Show a toast in Popup UI.
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (tabs && tabs.length > 0) {
+      const activeTab = tabs[0];
+      const title = activeTab.title || "";
+      const url = activeTab.url || "";
+      const textToCopy = `${title} - ${url}`;
+      navigator.clipboard
+        .writeText(textToCopy)
+        .then(() => {
+          console.log("Page info copied successfully:", textToCopy);
+          sendResponse({ success: true });
+        })
+        .catch((err) => {
+          console.error("Failed to copy page info:", err);
+          sendResponse({ success: false, error: err });
+        });
+    } else {
+      sendResponse({ success: false, error: "No active tab found" });
+    }
+  });
+}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -60,6 +60,7 @@ import * as DigestManagement from "./features/digest-management";
 import { BookmarkStorage } from "./features/BookmarkStorage.ts";
 import { openTabsPage } from "./features/tabs-helpers.ts";
 import { handleServiceWorkerMessage } from "./features/service-worker-handler";
+import { triggerCopyPageInfo } from "./popup/popup-messages";
 
 // Entrypoint logging:
 console.log("service-worker.ts", new Date());
@@ -109,6 +110,11 @@ chrome.commands.onCommand.addListener((command) => {
           }
         },
       );
+      break;
+
+    case "copy-page-info":
+      console.log("Triggering copy-page-info command");
+      triggerCopyPageInfo();
       break;
 
     default:


### PR DESCRIPTION
This pull request introduces a new feature to copy the current page's title and URL for sharing, along with the necessary integration into the existing Chrome extension. The most important changes include adding a new command to the manifest, handling messages in the popup script, and integrating the new feature into the service worker.

New feature for copying page information:

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R43-R48): Added a new command `copy-page-info` with a suggested key binding of `Alt+Shift+C`.

Message handling in popup script:

* [`src/popup.ts`](diffhunk://#diff-474e648025143539d50a25990e184704979011829c74eabd70592fa7a7bae6a6R6-R10): Imported the `handleMessages` function and added a listener for runtime messages to handle the new `copy-page-info` action.
* [`src/popup/popup-messages.ts`](diffhunk://#diff-a6cb4981caf30e575650e69b3668308ac870e0a5e4a6af8675285f236969b30fR1-R59): Created a new file to provide functions for handling popup interactions, including the `triggerCopyPageInfo` function to send the copy-page-info message and the `handleMessages` function to process it.

Integration into service worker:

* [`src/service-worker.ts`](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R63): Imported the `triggerCopyPageInfo` function and added a case in the command listener to trigger the new copy-page-info command. [[1]](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R63) [[2]](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R115-R119)