### PR TITLE
Hotkey support to open Side Panel UI and trigger an action.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,12 @@
         "default": "Alt+Shift+C"
       },
       "description": "Copy the current page title and URL for sharing."
+    },
+    "open-side-panel": {
+      "suggested_key": {
+        "default": "Alt+Shift+K"
+      },
+      "description": "Open the side panel."
     }
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -7,11 +7,13 @@
   </head>
   <body>
     <header>
-      <h1>Hacky-Helper</h1>
+      <h1>H-H: Side</h1>
       <div class="settings">
         <a href="settings.html" target="_blank">⚙️<br />settings</a>
       </div>
     </header>
+
+    <button id="openSidePanelButton">Open Side Panel</button>
 
     <div class="migrate-button-container">
       <button id="migrateTabButton">Migrate Current Tab</button>

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -1,0 +1,2 @@
+// Message types for Side Panel.
+export const SP_TRIGGER = "SP_TRIGGER";

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -4,6 +4,7 @@ import { CONFIG_RO, ConfigStore } from "./features/config-store";
 import { MIGRATE_TAB } from "./lib/constants";
 import serviceWorkerInterface from "./features/service-worker-interface";
 import { handleMessages } from "./popup/popup-messages";
+import { openSidePanel } from "./sidepanel-helper";
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return handleMessages(message, sender, sendResponse);
@@ -234,6 +235,10 @@ async function migrateTab(tabId: number, windowId: number) {
 
 // Initialize the UI when the document is loaded
 document.addEventListener("DOMContentLoaded", async () => {
+  const sidePanelButton = document.getElementById("openSidePanelButton");
+  if (sidePanelButton) {
+    sidePanelButton.addEventListener("click", openSidePanel);
+  }
   await initializeToggles();
 
   // Add event listener for the migrate button

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -60,6 +60,7 @@ import { BookmarkStorage } from "./features/BookmarkStorage.ts";
 import { openTabsPage } from "./features/tabs-helpers.ts";
 import { handleServiceWorkerMessage } from "./features/service-worker-handler";
 import { triggerCopyPageInfo } from "./popup/popup-messages";
+import { openSidePanel } from "./sidepanel-helper";
 
 // Entrypoint logging:
 console.log("service-worker.ts", new Date());
@@ -69,6 +70,10 @@ chrome.commands.onCommand.addListener((command) => {
   console.log(`Command received: ${command}`);
 
   switch (command) {
+    case "open-side-panel":
+      openSidePanel();
+      break;
+
     case "open-tabs-page":
       console.log("Opening tabs page");
       openTabsPage();

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -61,6 +61,7 @@ import { openTabsPage } from "./features/tabs-helpers.ts";
 import { handleServiceWorkerMessage } from "./features/service-worker-handler";
 import { triggerCopyPageInfo } from "./popup/popup-messages";
 import { openSidePanel } from "./sidepanel-helper";
+import { SP_TRIGGER } from "./messages/messages.ts";
 
 // Entrypoint logging:
 console.log("service-worker.ts", new Date());
@@ -71,6 +72,7 @@ chrome.commands.onCommand.addListener((command) => {
 
   switch (command) {
     case "open-side-panel":
+      chrome.runtime.sendMessage({ type: SP_TRIGGER });
       openSidePanel();
       break;
 

--- a/src/sidepanel-helper.ts
+++ b/src/sidepanel-helper.ts
@@ -1,0 +1,22 @@
+/**
+ * Opens the Chrome extension's side panel.
+ */
+export function openSidePanel(): void {
+  // TODO: rewrite this to use promise instead of callback
+  chrome.windows.getCurrent({ populate: false }, (currentWindow) => {
+    if (currentWindow && currentWindow.id !== undefined) {
+      chrome.sidePanel.open({ windowId: currentWindow.id }, () => {
+        if (chrome.runtime.lastError) {
+          console.error(
+            "Failed to open side panel:",
+            chrome.runtime.lastError.message,
+          );
+        } else {
+          console.log("Side panel opened successfully.");
+        }
+      });
+    } else {
+      console.error("Failed to detect the current window.");
+    }
+  });
+}

--- a/src/sidepanel.ts
+++ b/src/sidepanel.ts
@@ -8,6 +8,7 @@ import { CONFIG_RO } from "./features/config-store.ts";
 import { OLLAMA_API_URL_DEFAULT } from "./lib/constants.ts";
 import { component_model } from "./components.ts";
 import "./sidepanel.css";
+import { SP_TRIGGER } from "./messages/messages.ts";
 
 // Initialize LLM services
 let ollamaService: OllamaLLMService | null = null;
@@ -215,6 +216,23 @@ function restoreChoices(id: number) {
     custom_prompt.value = "";
   }
 }
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.type === SP_TRIGGER) {
+    console.log("SP_TRIGGER received");
+    chrome.windows.getCurrent((currentWindow) => {
+      if (currentWindow.focused) {
+        console.log(
+          "Side panel is the currently focused window. Triggering inspect_page.",
+        );
+        inspect_page();
+      } else {
+        console.log("Side panel is not the focused window.");
+      }
+    });
+    sendResponse({ status: "success" });
+  }
+});
 
 // Also exntention event handlers:
 chrome.tabs.onActivated.addListener((activeInfo) => {


### PR DESCRIPTION
This pull request introduces functionality to open a side panel in the Chrome extension, including UI updates, keyboard shortcut support, and message handling. The most significant changes involve adding a new `openSidePanel` function, integrating it with the UI and service worker, and introducing a new message type (`SP_TRIGGER`) for communication.

### Side Panel Functionality:

* **New `openSidePanel` Functionality**: Added the `openSidePanel` function in `src/sidepanel-helper.ts` to handle opening the Chrome extension's side panel. It includes error handling and logging for debugging purposes.

* **Message Handling for Side Panel**: Introduced a new message type, `SP_TRIGGER`, in `src/messages/messages.ts` to facilitate communication between components for side panel actions. Added a message listener in `src/sidepanel.ts` to handle `SP_TRIGGER` messages and trigger relevant actions. [[1]](diffhunk://#diff-65082ac5629583452df42f40a0137c77cea08ab85169ff8823a1ae2fd5f93e6cR1-R2) [[2]](diffhunk://#diff-9f379b4d5cc9f3b202a24353e98382861a5d23db821242e7efb8d0f457a9098cR11) [[3]](diffhunk://#diff-9f379b4d5cc9f3b202a24353e98382861a5d23db821242e7efb8d0f457a9098cR220-R236)

### UI Enhancements:

* **UI Update in Popup**: Added a new "Open Side Panel" button to `popup.html` and connected it to the `openSidePanel` function in `src/popup.ts`. This allows users to open the side panel directly from the popup interface. [[1]](diffhunk://#diff-28d0d8f0960f87f8d291caace058de871b8145e54d727271b564eba832123ec8L10-R17) [[2]](diffhunk://#diff-474e648025143539d50a25990e184704979011829c74eabd70592fa7a7bae6a6R238-R241)

### Keyboard Shortcut Integration:

* **New Keyboard Shortcut**: Added a keyboard shortcut (`Alt+Shift+K`) to open the side panel. This was implemented in `manifest.json` and integrated with the service worker to trigger the `openSidePanel` function. [[1]](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743R49-R54) [[2]](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R74-R78)

### Service Worker Updates:

* **Service Worker Support for Side Panel**: Updated `src/service-worker.ts` to handle the new `SP_TRIGGER` message and execute the `openSidePanel` function when the "open-side-panel" command is received. [[1]](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R63-R64) [[2]](diffhunk://#diff-0aba05b7e68a2bb0e8cebbd6297fafc218eaeff08345a12bd379181c4a88e454R74-R78)