### PR TITLE
Update "Force Sync" actino label in Tabs UI

### DIFF
--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -580,7 +580,7 @@ function createSessionListItem(
     // Actions for named sessions
     sessionLabel.menuItems = [
       {
-        text: "Force Sync to Bookmarks",
+        text: "Force Sync to Backend",
         onClick: () => forceSyncSession(sessionId),
       },
       {

--- a/taskdocs/DONE_force_sync_action_label.md
+++ b/taskdocs/DONE_force_sync_action_label.md
@@ -1,0 +1,23 @@
+# METAPLAN Phase Documentation
+
+## Task: Update Action Label for "Force Sync"
+
+### Description
+
+Update the action label for "Force Sync" in the session menu from "Force Sync to Bookmarks" to "Force Sync to Backend".
+
+### Planned Steps
+
+1.  Locate the relevant code in `src/tabs.ts` within the `createSessionListItem` function.
+2.  Modify the `text` property of the menu item from `"Force Sync to Bookmarks"` to `"Force Sync to Backend"` using `replace_in_file`.
+3.  Verify the changes after applying the modification.
+
+### Status
+
+- [x] Task completed successfully.
+
+### Notes
+
+- Code in `src/tabs.ts` updated.
+- Label changed from "Force Sync to Bookmarks" to "Force Sync to Backend".
+- Code formatted using Prettier.


### PR DESCRIPTION
This pull request updates the label for a menu action in the session menu and documents the change in the task documentation. The most important changes are as follows:

### Label Update:
* In the `createSessionListItem` function in `src/tabs.ts`, the label for the "Force Sync" action was updated from `"Force Sync to Bookmarks"` to `"Force Sync to Backend"`.

### Documentation:
* Added a new file `taskdocs/DONE_force_sync_action_label.md` to document the task of updating the "Force Sync" label, including the description, steps taken, and completion status.